### PR TITLE
Whitenoise upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
 - Alternately, you can fork this repo and then clone your fork.
 - Change to the backend directory you just cloned: 
   `cd backend`
-
+- Create a directory for your static files (normally it will be ignored by git)
+  `mkdir backend/staticfiles`
+    
 ## Set up a virtual environment with a python3.6 interpreter(Ubuntu):
 ```
 virtualenv --python={PATH_TO_PYTHON3.6} dcmpa
@@ -66,11 +68,19 @@ If you get an error, you may need to open the `requiremnts.txt` file and replace
   `python manage.py createsuperuser`
 
   - You will be prompted by Django to create a super user, and you can use these credentials to log into the admin interface (more in next step)
+  
 
-## Start django server :
-```
-python manage.py runserver
-```
+## Start django:
+- collect static, so you can run the django admin. You will run this command when you add or update static files:
+  `python manage.py collectstatic`
+
+- Run the server
+  `python manage.py runserver`
+
+- Navigate to the django admin:
+  `http://localhost:8000/admin/`
+  If you see a login screen, everything worked!
+
 
 ## Deployment
 - master branch:- staging branch

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -41,16 +41,16 @@ ALLOWED_HOSTS = []
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+     # whitenoise needs to be directly after security and before all others
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     # Must have in order to use the admin:
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware'
-
+    'django.contrib.messages.middleware.MessageMiddleware'
 ]
 
 ROOT_URLCONF = 'backend.urls'

--- a/backend/settings/dev.py
+++ b/backend/settings/dev.py
@@ -47,7 +47,7 @@ STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles/')
 STATICFILES_DIRS = (
     os.path.join(PROJECT_ROOT, "static"),
 )
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Cloudinary Media Url 
 MEDIA_URL = 'https://res.cloudinary.com/thehub/'


### PR DESCRIPTION
@koolamusic , the changes needed were pretty minimal, mostly just changing `whitenoise.django.GzipManifestStaticFilesStorage` to `whitenoise.storage.CompressedManifestStaticFilesStorage`.

I updated the readme as well, I thought running `collectstatic` would create the `staticfiles` directory, but that was not the case. Since staticfiles is included in gitignore, I thought I'd add a step to the readme, telling people to create it.